### PR TITLE
Search with contains/like ga profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-analytics",
   "description": "A hubot script to get google analytics reports",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Plan B Comunicação <dev@planb.com.br>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, google analytics, ga",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "date-utils": "^1.2.19",
-    "googleapis": "^4.0.0"
+    "googleapis": "^4.0.0",
+    "underscore.string": "^3.3.4"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/src/lib/HubotAnalytics.js
+++ b/src/lib/HubotAnalytics.js
@@ -1,19 +1,28 @@
+var _ = require("underscore");
+var s = require("underscore.string");
 
 function HubotAnalytics() {
-  this.profilesNames = "";
+  this.profilesNames = {};
 }
 
 HubotAnalytics.prototype.getSiteId = function(siteMatch) {
-  var site = siteMatch;
-  var targetGa = site.replace(/"/g, '');
+  siteMatch = siteMatch.replace(/"/g, '');
 
-  var tryValueByName = this.profilesNames[targetGa];
-  if(tryValueByName != undefined) {
-    targetGa = tryValueByName;
+  var gaByName = this.profilesNames[siteMatch];
+
+  if(gaByName != undefined) {
+    return gaByName; //found by exact name
+  } else {
+    var gaByContainsName = _.find(this.profilesNames, function(item, key){
+                return s.include(key, siteMatch);
+              });
+
+    if(gaByContainsName != undefined) {
+      return gaByContainsName; //found by "like name"
+    } else {
+      return siteMatch; //return inputed ga code
+    }
   }
-
-  return targetGa;
 };
-
 
 module.exports = HubotAnalytics;

--- a/src/lib/HubotAnalytics.js
+++ b/src/lib/HubotAnalytics.js
@@ -1,6 +1,6 @@
 
 function HubotAnalytics() {
-  this.profilesNames = "ok";
+  this.profilesNames = "";
 }
 
 HubotAnalytics.prototype.getSiteId = function(siteMatch) {


### PR DESCRIPTION
Example:

```
Spike> analytics profiles
Spike> Shell: 1857955 - Plan B - Site
86975907 - Plan B U
96055266 - Test 1 [FILTRO]
14238052 - Hotsite test [FILTRO]
```

Search by "Plan":

```
Spike> analytics pageviews "Plan"
Spike> Shell: Plan B - Site: 1749 visits and 1895 pageviews.
```
